### PR TITLE
fix: Removed version declaration & renamed compose files.

### DIFF
--- a/elasticsearch-kibana/compose.yml
+++ b/elasticsearch-kibana/compose.yml
@@ -1,6 +1,3 @@
-# Version of docker-compose file is no longer required
-version: '3.9'
-
 services:
 
   elasticsearch:

--- a/mysql-phpmyadmin/compose.yml
+++ b/mysql-phpmyadmin/compose.yml
@@ -1,6 +1,3 @@
-# Version of docker-compose file is no longer required
-version: '3.3'
-
 services:
 
   mysql:

--- a/postgres-pgadmin/compose.yml
+++ b/postgres-pgadmin/compose.yml
@@ -1,6 +1,3 @@
-# Version of docker-compose file is no longer required
-version: '3.3'
-
 services:
 
   postgres:


### PR DESCRIPTION
## What
**The PR tries to resolve #7.**

- Removed version declaration (along with comment) from docker-compose.yml
- Renamed docker-compose.yml to compose.yml

## Why

As [Compose v2](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command) now supports compose command; We shall adopt and migrate to the new syntax for compose files.

- [x] I will abide by the [code of conduct](https://github.com/bhavik2936/docker-compose-files/blob/main/.github/CODE_OF_CONDUCT.md).
