### PR TITLE
Add MongoDB compose setup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ List of Docker Compose setups.
 
 - [`Elasticsearch / Kibana`](https://github.com/bhavik2936/docker-compose-files/blob/main/elasticsearch-kibana) - Passwordless setup of Elasticsearch search engine with Kibana visualizer.
 
+- [`Mongo / Mongo-Express`](https://github.com/bhavik2936/docker-compose-files/blob/main/mongo-mongo-express) - Basic setup of MongoDB database with Mongo Express.
+
 ## Feedback
 Suggestions/improvements are [welcomed](https://github.com/bhavik2936/docker-compose-files/issues)!


### PR DESCRIPTION
## What
- Add MongoDB folder link to the README.md

## Why
- There is a MongoDB compose folder in the repository but the link to it was not present like for other compose folders.

- [x] I will abide by the [code of conduct](https://github.com/bhavik2936/docker-compose-files/blob/main/.github/CODE_OF_CONDUCT.md).
